### PR TITLE
Fixed typo and made doc more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ To change the items that create nodes, you may need to change the name.
 class MyComponent {
     constructor() {
         super("My comp");
-        this.contextMenuItem = "Add My comp";
+        this.contextMenuName = "Add My comp";
     }
 }
 ///
-rename(component) { return component.contextMenuItem || contextMenuItem.name }
+rename(component) { return component.contextMenuName || component.name }
 ```


### PR DESCRIPTION
I changed `contextMenuItem.name` to `component.name` in the readme as I believe this was a typo.

Also changed `contextMenuItem` to `contextMenuName` to make it a little bit more clear.