### PR TITLE
Implement ability to add node specific menu items

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ editor.use(ContextMenuPlugin, {
     nodeItems: {
         'Click me'(){ console.log('Works for node!') }
     },
+    getNodeItems: node => {
+        if (node.name === 'Add') {
+            return {
+                'Only for Add nodes': () => { console.log('Works for add node!') },
+            };
+        }
+    },
     vueComponent: CustomVueComponent // extends Menu
 });
 ```
@@ -32,6 +39,7 @@ editor.use(ContextMenuPlugin, {
 | `rename` | function for renaming of items| `component => component.name`
 | `items` | custom items (`Object` with nested objects and functions) | `{}`
 | `nodeItems` | custom items for Node menu | `{}`
+| `getNodeItems` | a function that returns nodeItems for a specific node (arg: Node) | `() => undefined`
 
 
 You can arbitrarily put a component in a submenu. Examples: 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ editor.use(ContextMenuPlugin, {
 | `rename` | function for renaming of items| `component => component.name`
 | `items` | custom items (`Object` with nested objects and functions) | `{}`
 | `nodeItems` | custom items for Node menu | `{}`
-| `getNodeItems` | a function that returns nodeItems for a specific node (arg: Node) | `() => undefined`
+| `getNodeItems` | a function that returns nodeItems for a specific node (arg: Node) | `() => ({})`
 
 
 You can arbitrarily put a component in a submenu. Examples: 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ editor.use(ContextMenuPlugin, {
     nodeItems: {
         'Click me'(){ console.log('Works for node!') }
     },
-    getNodeItems: node => {
+    // OR
+    nodeItems: node => {
         if (node.name === 'Add') {
             return {
-                'Only for Add nodes': () => { console.log('Works for add node!') },
+                'Only for Add nodes'() => { console.log('Works for add node!') },
             };
+        }
+        return { 
+            'Click me'(){ console.log('Works for node!') }
         }
     },
     vueComponent: CustomVueComponent // extends Menu
@@ -38,8 +42,7 @@ editor.use(ContextMenuPlugin, {
 | `allocate` | function for placing of components into submenu | `() => []`
 | `rename` | function for renaming of items| `component => component.name`
 | `items` | custom items (`Object` with nested objects and functions) | `{}`
-| `nodeItems` | custom items for Node menu | `{}`
-| `getNodeItems` | a function that returns nodeItems for a specific node (arg: Node) | `() => ({})`
+| `nodeItems` | custom items for Node menu or a function that returns node items | `{}`
 
 
 You can arbitrarily put a component in a submenu. Examples: 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rete-context-menu-plugin",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vrp-rete-context-menu-plugin",
-  "version": "0.4.1",
+  "name": "rete-context-menu-plugin",
+  "version": "0.4.0",
   "description": "",
   "main": "build/context-menu-plugin.common.js",
   "module": "build/context-menu-plugin.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rete-context-menu-plugin",
-  "version": "0.4.0",
+  "name": "vrp-rete-context-menu-plugin",
+  "version": "0.4.1",
   "description": "",
   "main": "build/context-menu-plugin.common.js",
   "module": "build/context-menu-plugin.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import VueItem from './menu/Item.vue';
 import VueMenu from './menu/Menu.vue';
 import VueSearch from './menu/Search.vue';
 
-import merge from 'lodash/merge';
+import isFunction from 'lodash/isFunction';
 
 function install(editor, {
     searchBar = true,
@@ -12,7 +12,6 @@ function install(editor, {
     delay = 1000,
     items = {},
     nodeItems = {},
-    getNodeItems = () => ({}),
     allocate = () => [],
     rename = component => component.name,
     vueComponent = null
@@ -36,9 +35,8 @@ function install(editor, {
     editor.on('contextmenu', ({ e, node }) => {
         e.preventDefault();
         e.stopPropagation();
-        const allNodeItems = node ? merge(nodeItems, getNodeItems(node)) : null;
-        
-        nodeMenu = node ? new NodeMenu(editor, { searchBar: false, delay }, vueComponent, allNodeItems) : nodeMenu;
+        nodeItems = isFunction(nodeItems) ? nodeItems(node) : nodeItems;
+        nodeMenu = node ? new NodeMenu(editor, { searchBar: false, delay }, vueComponent, nodeItems) : nodeMenu;
 
         const [x, y] = [e.clientX, e.clientY];
         const menu = node ? nodeMenu : mainMenu;

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,15 @@ import VueItem from './menu/Item.vue';
 import VueMenu from './menu/Menu.vue';
 import VueSearch from './menu/Search.vue';
 
+import merge from 'lodash/merge';
+
 function install(editor, {
     searchBar = true,
     searchKeep = () => false,
     delay = 1000,
     items = {},
     nodeItems = {},
+    getNodeItems = () => ({}),
     allocate = () => [],
     rename = component => component.name,
     vueComponent = null
@@ -17,11 +20,13 @@ function install(editor, {
     editor.bind('hidecontextmenu');
 
     const mainMenu = new MainMenu(editor, { searchBar, searchKeep, delay }, vueComponent, { items, allocate, rename });
-    const nodeMenu = new NodeMenu(editor, { searchBar: false, delay }, vueComponent, nodeItems);
+    let nodeMenu = null;
 
     editor.on('hidecontextmenu', () => {
         mainMenu.hide();
-        nodeMenu.hide();
+        if (nodeMenu) {
+            nodeMenu.hide();
+        }
     });
 
     editor.on('click contextmenu', () => {
@@ -31,6 +36,9 @@ function install(editor, {
     editor.on('contextmenu', ({ e, node }) => {
         e.preventDefault();
         e.stopPropagation();
+        const allNodeItems = node ? merge(nodeItems, getNodeItems(node)) : null;
+        
+        nodeMenu = node ? new NodeMenu(editor, { searchBar: false, delay }, vueComponent, allNodeItems) : nodeMenu;
 
         const [x, y] = [e.clientX, e.clientY];
         const menu = node ? nodeMenu : mainMenu;


### PR DESCRIPTION
Added an option called `getNodeItems` that will be called for each of the nodes and should return `nodeItems`. The user can implement whatever logic best fits to return node specific menu items.