### PR TITLE
No more Pug

### DIFF
--- a/lib/debounce.js
+++ b/lib/debounce.js
@@ -1,0 +1,16 @@
+/**
+ * Debounce
+ * @see https://www.matthewgerstman.com/tech/throttle-and-debounce/
+ * @param {Function} next
+ * @param {number} ms
+ * @return {Function}
+ */
+export default function debounce(next, ms) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      next(...args);
+    }, ms);
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rete-context-menu-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -843,21 +843,6 @@
         }
       }
     },
-    "@types/babel-types": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.4.tgz",
-      "integrity": "sha512-WiZhq3SVJHFRgRYLXvpf65XnV6ipVHhnNaNvE8yCimejrGglkg38kEj0JcizqwSHxmPSjcTlig/6JouxLGEhGw==",
-      "dev": true
-    },
-    "@types/babylon": {
-      "version": "6.16.3",
-      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.3.tgz",
-      "integrity": "sha512-lyJ8sW1PbY3uwuvpOBZ9zMYKshMnQpXmeDHh8dj9j2nJm/xrW0FgB5gLSYOArj5X0IfaXnmhFoJnhS4KbqIMug==",
-      "dev": true,
-      "requires": {
-        "@types/babel-types": "*"
-      }
-    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -914,29 +899,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "acorn": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-      "dev": true
-    },
-    "acorn-globals": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-      "dev": true,
-      "requires": {
-        "acorn": "^4.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
-    },
     "acorn-jsx": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
@@ -953,17 +915,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -1040,12 +991,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -2101,12 +2046,6 @@
       "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
       "dev": true
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true
-    },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
@@ -2143,16 +2082,6 @@
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
       "dev": true
     },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
-    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -2164,15 +2093,6 @@
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
-      }
-    },
-    "character-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-      "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
-      "dev": true,
-      "requires": {
-        "is-regex": "^1.0.3"
       }
     },
     "chardet": {
@@ -2254,17 +2174,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      }
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -2389,18 +2298,6 @@
       "dev": true,
       "requires": {
         "bluebird": "^3.1.1"
-      }
-    },
-    "constantinople": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
-      "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
-      "dev": true,
-      "requires": {
-        "@types/babel-types": "^7.0.0",
-        "@types/babylon": "^6.16.2",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0"
       }
     },
     "convert-source-map": {
@@ -2588,12 +2485,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "doctypes": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=",
-      "dev": true
     },
     "dot-prop": {
       "version": "4.2.0",
@@ -3090,12 +2981,6 @@
         "rimraf": "2"
       }
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -3125,15 +3010,6 @@
       "dev": true,
       "requires": {
         "globule": "^1.0.0"
-      }
-    },
-    "gen-pug-source-map": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/gen-pug-source-map/-/gen-pug-source-map-0.1.2.tgz",
-      "integrity": "sha1-3nk4fo310BZ91UrC8pgxfx53IwQ=",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.5.6"
       }
     },
     "generate-function": {
@@ -3264,15 +3140,6 @@
         "commander": "^2.9.0",
         "is-my-json-valid": "^2.12.4",
         "pinkie-promise": "^2.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -3576,24 +3443,6 @@
         "is-primitive": "^2.0.0"
       }
     },
-    "is-expression": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
-      "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
-      "dev": true,
-      "requires": {
-        "acorn": "~4.0.2",
-        "object-assign": "^4.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -3691,15 +3540,6 @@
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -3755,12 +3595,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-      "dev": true
-    },
-    "js-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
       "dev": true
     },
     "js-tokens": {
@@ -3857,16 +3691,6 @@
         }
       }
     },
-    "jstransformer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
-      "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.0.0",
-        "promise": "^7.0.1"
-      }
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -3884,12 +3708,6 @@
       "requires": {
         "graceful-fs": "^4.1.9"
       }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
     },
     "lcid": {
       "version": "1.0.0",
@@ -3975,12 +3793,6 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
-      "dev": true
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loose-envify": {
@@ -4790,145 +4602,10 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "pug": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.3.tgz",
-      "integrity": "sha1-ccuoJTfJWl6rftBGluQiH1Oqh44=",
-      "dev": true,
-      "requires": {
-        "pug-code-gen": "^2.0.1",
-        "pug-filters": "^3.1.0",
-        "pug-lexer": "^4.0.0",
-        "pug-linker": "^3.0.5",
-        "pug-load": "^2.0.11",
-        "pug-parser": "^5.0.0",
-        "pug-runtime": "^2.0.4",
-        "pug-strip-comments": "^1.0.3"
-      }
-    },
-    "pug-attrs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.3.tgz",
-      "integrity": "sha1-owlflw5kFR972tlX7vVftdeQXRU=",
-      "dev": true,
-      "requires": {
-        "constantinople": "^3.0.1",
-        "js-stringify": "^1.0.1",
-        "pug-runtime": "^2.0.4"
-      }
-    },
-    "pug-code-gen": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.1.tgz",
-      "integrity": "sha1-CVHsgyJddNjPxHan+Zolm199BQw=",
-      "dev": true,
-      "requires": {
-        "constantinople": "^3.0.1",
-        "doctypes": "^1.1.0",
-        "js-stringify": "^1.0.1",
-        "pug-attrs": "^2.0.3",
-        "pug-error": "^1.3.2",
-        "pug-runtime": "^2.0.4",
-        "void-elements": "^2.0.1",
-        "with": "^5.0.0"
-      }
-    },
-    "pug-error": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.2.tgz",
-      "integrity": "sha1-U659nSm7A89WRJOgJhCfVMR/XyY=",
-      "dev": true
-    },
-    "pug-filters": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.0.tgz",
-      "integrity": "sha1-JxZVVbwEwjbkqisDZiRt+gIbYm4=",
-      "dev": true,
-      "requires": {
-        "clean-css": "^4.1.11",
-        "constantinople": "^3.0.1",
-        "jstransformer": "1.0.0",
-        "pug-error": "^1.3.2",
-        "pug-walk": "^1.1.7",
-        "resolve": "^1.1.6",
-        "uglify-js": "^2.6.1"
-      }
-    },
-    "pug-lexer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.0.0.tgz",
-      "integrity": "sha1-IQwYRX7y4XYCQnQMXmR715TOwng=",
-      "dev": true,
-      "requires": {
-        "character-parser": "^2.1.1",
-        "is-expression": "^3.0.0",
-        "pug-error": "^1.3.2"
-      }
-    },
-    "pug-linker": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.5.tgz",
-      "integrity": "sha1-npp65ABWgtAn3uuWsAD4juuDoC8=",
-      "dev": true,
-      "requires": {
-        "pug-error": "^1.3.2",
-        "pug-walk": "^1.1.7"
-      }
-    },
-    "pug-load": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.11.tgz",
-      "integrity": "sha1-5kjlftET/iwfRdV4WOorrWvAFSc=",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.0",
-        "pug-walk": "^1.1.7"
-      }
-    },
-    "pug-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.0.tgz",
-      "integrity": "sha1-45Stmz/KkxI5QK/4hcBuRKt+aOQ=",
-      "dev": true,
-      "requires": {
-        "pug-error": "^1.3.2",
-        "token-stream": "0.0.1"
-      }
-    },
-    "pug-runtime": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.4.tgz",
-      "integrity": "sha1-4XjhvaaKsujArPybztLFT9iM61g=",
-      "dev": true
-    },
-    "pug-strip-comments": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.3.tgz",
-      "integrity": "sha1-8VWVkiBu3G+FMQ2s9K+0igJa9Z8=",
-      "dev": true,
-      "requires": {
-        "pug-error": "^1.3.2"
-      }
-    },
-    "pug-walk": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.7.tgz",
-      "integrity": "sha1-wA1cUSi6xYBr7BXSt+fNq+QlMfM=",
       "dev": true
     },
     "pump": {
@@ -5658,15 +5335,6 @@
         "rollup-plugin-uglify": "^4.0.0"
       }
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "^0.1.1"
-      }
-    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -5694,18 +5362,6 @@
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "rollup-pluginutils": "^2.3.0"
-      }
-    },
-    "rollup-plugin-pug": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-pug/-/rollup-plugin-pug-0.1.6.tgz",
-      "integrity": "sha1-xGydYo9T0mTywFYk28WRK0gbQC0=",
-      "dev": true,
-      "requires": {
-        "gen-pug-source-map": "^0.1.2",
-        "pug": ">=2.0.0-rc.1 <3",
-        "pug-runtime": "^2.0.3",
-        "rollup-pluginutils": "^2.0.1"
       }
     },
     "rollup-plugin-regenerator": {
@@ -6242,12 +5898,6 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
-    "token-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
-      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo=",
-      "dev": true
-    },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
@@ -6320,24 +5970,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
-      "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -6431,12 +6063,6 @@
         }
       }
     },
-    "void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
-      "dev": true
-    },
     "vue": {
       "version": "2.5.17",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.17.tgz",
@@ -6482,28 +6108,6 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true
-    },
-    "with": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
-      "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
-      "dev": true,
-      "requires": {
-        "acorn": "^3.1.0",
-        "acorn-globals": "^3.0.0"
-      }
-    },
-    "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-      "dev": true
-    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -6546,18 +6150,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      }
     },
     "yargs-parser": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3956,7 +3956,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "rete-cli": "^0.5.0",
-    "rollup-plugin-pug": "^0.1.6",
     "rollup-plugin-sass": "^0.6.1",
     "rollup-plugin-vue": "^4.3.2",
     "vue-template-compiler": "^2.5.17"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "url": "https://github.com/retejs/context-menu-plugin.git"
   },
   "dependencies": {
-    "lodash": "^4.17.11",
     "vue": "^2.5.17"
   },
   "devDependencies": {

--- a/rete.config.js
+++ b/rete.config.js
@@ -1,4 +1,3 @@
-import pug from 'rollup-plugin-pug';
 import sass from 'rollup-plugin-sass';
 import vue from 'rollup-plugin-vue';
 
@@ -9,9 +8,6 @@ export default {
         'vue': 'Vue'
     },
     plugins: [
-        pug({
-            pugRuntime: false
-        }),
         sass({
             insert: true
         }),

--- a/rete.config.js
+++ b/rete.config.js
@@ -6,8 +6,7 @@ export default {
     input: 'src/index.js',
     name: 'ContextMenuPlugin',
     globals: {
-        'vue': 'Vue',
-        'lodash': '_'
+        'vue': 'Vue'
     },
     plugins: [
         pug({

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,6 @@ import VueItem from './menu/Item.vue';
 import VueMenu from './menu/Menu.vue';
 import VueSearch from './menu/Search.vue';
 
-import isFunction from 'lodash/isFunction';
-
 function install(editor, {
     searchBar = true,
     searchKeep = () => false,
@@ -38,7 +36,7 @@ function install(editor, {
         const [x, y] = [e.clientX, e.clientY];
 
         if(node) {
-            menu = new NodeMenu(editor, { searchBar: false, delay }, vueComponent,  isFunction(nodeItems) ? nodeItems(node) : nodeItems);
+            menu = new NodeMenu(editor, { searchBar: false, delay }, vueComponent,  typeof nodeItems === 'function' ? nodeItems(node) : nodeItems);
             menu.show(x, y, { node });
         } else {
             menu = new MainMenu(editor, { searchBar, searchKeep, delay }, vueComponent, { items, allocate, rename });

--- a/src/menu/Item.vue
+++ b/src/menu/Item.vue
@@ -1,17 +1,18 @@
-<template lang="pug">
-.item(
-  @click="onClick($event)"
-  @mouseover="showSubitems()"
-  @mouseleave="timeoutHide()"
-  :class="{ hasSubitems }"
-) {{item.title}}
-  .subitems(v-show="hasSubitems && this.visibleSubitems")
-    Item(v-for="subitem in item.subitems"
-      :key="subitem.title"
-      :item="subitem"
-      :args="args"
-      :delay="delay"
-      )
+<template>
+  <div class="item"
+       @click="onClick($event)"
+       @mouseover="showSubitems()"
+       @mouseleave="timeoutHide()"
+       :class="{ hasSubitems }"
+  >{{item.title}}
+    <div class="subitems" v-show="hasSubitems && this.visibleSubitems">
+      <Item v-for="subitem in item.subitems"
+            :key="subitem.title"
+            :item="subitem"
+            :args="args"
+            :delay="delay"/>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -23,7 +24,7 @@ export default {
   props: { item: Object, args: Object },
   data() {
     return {
-      visibleSubitems: false, 
+      visibleSubitems: false,
     }
   },
   computed: {
@@ -41,7 +42,7 @@ export default {
     },
     onClick(e) {
       e.stopPropagation();
-      
+
       if(this.item.onClick)
         this.item.onClick(this.args);
       this.$root.$emit('hide');

--- a/src/menu/Menu.vue
+++ b/src/menu/Menu.vue
@@ -1,19 +1,19 @@
-<template lang="pug">
-.context-menu(
-  ref="menu"
-  v-if="visible"
-  v-bind:style="style",
-  @mouseleave='timeoutHide()',
-  @mouseover="cancelHide()"
-  @contextmenu.prevent=""
-)
-  Search(v-if="searchBar", v-model="filter", @search="onSearch")
-  Item(v-for='item in filtered'
-    :key="item.title"
-    :item="item"
-    :args="args"
-    :delay="delay / 2"
-  )
+<template>
+  <div class="context-menu"
+       ref="menu"
+       v-if="visible"
+       v-bind:style="style"
+       @mouseleave="timeoutHide()"
+       @mouseover="cancelHide()"
+       @contextmenu.prevent=""
+  >
+    <Search v-if="searchBar" v-model="filter" @search="onSearch"></Search>
+    <Item v-for="item in filtered"
+          :key="item.title"
+          :item="item"
+          :args="args"
+          :delay="delay / 2"/>
+  </div>
 </template>
 
 <script>
@@ -38,14 +38,14 @@ export default {
   computed: {
     style() {
       return {
-        top: this.y+'px', 
+        top: this.y+'px',
         left: this.x+'px'
       }
     },
     filtered() {
       if(!this.filter) return this.items;
       const regex = new RegExp(this.filter, 'i');
-      
+
       return this.extractLeafs(this.items)
         .filter(({ title }) => {
           return this.searchKeep(title) || title.match(regex)
@@ -72,7 +72,7 @@ export default {
       this.x = x;
       this.y = y;
       this.args = args;
-  
+
       this.cancelHide();
     },
     hide() {
@@ -97,7 +97,7 @@ export default {
   updated() {
     if(this.$refs.menu) {
       [this.x, this.y] = fitViewport([this.x, this.y], this.$refs.menu)
-    } 
+    }
   },
   mounted() {
     this.$root.$on('show', this.show);

--- a/src/menu/Search.vue
+++ b/src/menu/Search.vue
@@ -1,6 +1,7 @@
-<template lang="pug">
-.search
-  input(v-model="value")
+<template>
+  <div class="search">
+    <input v-model="value"/>
+  </div>
 </template>
 
 <script>
@@ -17,7 +18,7 @@ export default {
 
 <style lang="sass" scoped>
 .search
-  input    
+  input
     color: white
     padding: 1px 8px
     border: 1px solid white

--- a/src/menu/debounceHide.js
+++ b/src/menu/debounceHide.js
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import debounce from '../../lib/debounce';
 
 export default (hideMethod) => ({
     props: { delay: { type: Number, required: true } },
@@ -10,7 +10,7 @@ export default (hideMethod) => ({
     methods: {
         cancelHide() {
             const hide = this.timeoutHide;
-    
+
             if (hide && hide.cancel)
                 this.timeoutHide.cancel();
         }


### PR DESCRIPTION
Hello, Vitaliy.

I'm removed the Pug support.

Now you can import this plugin directly into your Vue app (with SASS compiler):

```js
import ContextMenuPlugin from 'rete-context-menu-plugin/src';
```

Import size of:

* `rete-context-menu-plugin` — 21.61 KB (parsed) or 5.94 KB (gzipped and minified);
* `rete-context-menu-plugin/src` — 6.31 KB (parsed) or 2.54 KB (gzipped and minified).

Best regards,
Sergey.

P.S. Also includes changes from #25 