### PR TITLE
Feature/position item add

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ editor.use(ContextMenuPlugin, {
     searchBar: false, // true by default
     searchKeep: title => true, // leave item when searching, optional. For example, title => ['Refresh'].includes(title)
     delay: 100,
+    addAtInitialPosition: false,
     allocate(component) {
         return ['Submenu'];
     },
@@ -45,6 +46,7 @@ editor.use(ContextMenuPlugin, {
 | `rename` | function for renaming of items| `component => component.name`
 | `items` | custom items (`Object` with nested objects and functions) | `{}`
 | `nodeItems` | custom items for Node menu or a function that returns node items | `{}`
+| `addAtInitialPosition` | if `true`, will add a new item at the position of the original first context click | `false`
 
 
 You can arbitrarily put a component in a submenu. Examples: 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ function install(editor, {
     nodeItems = {},
     allocate = () => [],
     rename = component => component.name,
-    vueComponent = null
+    vueComponent = null,
+    addAtInitialPosition = false
 }) {
     editor.bind('hidecontextmenu');
     editor.bind('showcontextmenu');
@@ -40,7 +41,7 @@ function install(editor, {
             menu = new NodeMenu(editor, { searchBar: false, delay }, vueComponent,  isFunction(nodeItems) ? nodeItems(node) : nodeItems);
             menu.show(x, y, { node });
         } else {
-            menu = new MainMenu(editor, { searchBar, searchKeep, delay }, vueComponent, { items, allocate, rename });
+            menu = new MainMenu(editor, { searchBar, searchKeep, delay, addAtInitialPosition }, vueComponent, { items, allocate, rename });
             menu.show(x, y);
         }
     });

--- a/src/main-menu.js
+++ b/src/main-menu.js
@@ -5,12 +5,18 @@ export default class MainMenu extends Menu {
     constructor(editor, props, vueComponent, { items, allocate, rename }) {
         super(editor, props, vueComponent);
         
-        const mouse = { x: 0, y: 0 };
+        const { x, y } = editor.view.area.mouse;
+        const mouse = { x, y };
 
-        editor.on('mousemove', ({ x, y }) => {
-            mouse.x = x;
-            mouse.y = y;
-        });
+        if (!props.addAtInitialPosition) {
+
+            editor.on('mousemove', ({ x, y }) => {
+                mouse.x = x;
+                mouse.y = y;
+            });
+        }
+        
+
         
         for(const component of editor.components.values()) {
             const path = allocate(component);


### PR DESCRIPTION
This adds the ability to determine where a new item will be added onto the editor. In combination with large submenus the position might be totally off. The current behavior (2) will add it at the mouse location of the last click, whereas setting the new option to true will place it at the original context click (1)

![2021-11-18_12h49_53](https://user-images.githubusercontent.com/2861414/142410840-c57ac555-066a-479b-b443-6e81690d334d.png)


