### PR TITLE
Make the items class name more specific to avoid naming conflicts.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rete-context-menu-plugin",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/common.sass
+++ b/src/common.sass
@@ -1,6 +1,6 @@
 @import './vars.sass'
 
-.item
+.rete-context-menu-item
   color: #fff
   padding: 4px
   border-bottom: 1px solid darken($context-color,8%)

--- a/src/menu/Item.vue
+++ b/src/menu/Item.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.item(
+.rete-context-menu-item(
   @click="onClick($event)"
   @mouseover="showSubitems()"
   @mouseleave="timeoutHide()"
@@ -23,7 +23,7 @@ export default {
   props: { item: Object, args: Object },
   data() {
     return {
-      visibleSubitems: false, 
+      visibleSubitems: false,
     }
   },
   computed: {
@@ -41,7 +41,7 @@ export default {
     },
     onClick(e) {
       e.stopPropagation();
-      
+
       if(this.item.onClick)
         this.item.onClick(this.args);
       this.$root.$emit('hide');
@@ -55,8 +55,8 @@ export default {
 @import '../vars.sass'
 @import '../common.sass'
 
-.item
-  @extend .item
+.rete-context-menu-item
+  @extend .rete-context-menu-item
   &.hasSubitems:after
     content: '►'
     position: absolute
@@ -69,5 +69,5 @@ export default {
     left: 100%
     width: $width
     .subitem
-      @extend .item
+      @extend .rete-context-menu-item
 </style>

--- a/src/menu/Menu.vue
+++ b/src/menu/Menu.vue
@@ -46,11 +46,11 @@ export default {
     filtered() {
       if(!this.filter) return this.items;
       const regex = new RegExp(this.filter, 'i');
-      
+
       return this.extractLeafs(this.items)
         .filter(({ title }) => {
           return this.searchKeep(title) || title.match(regex)
-        });
+      });
     }
   },
   methods: {
@@ -73,7 +73,7 @@ export default {
       this.x = x;
       this.y = y;
       this.args = args;
-  
+
       this.cancelHide();
     },
     hide() {
@@ -98,7 +98,7 @@ export default {
   updated() {
     if(this.$refs.menu) {
       [this.x, this.y] = fitViewport([this.x, this.y], this.$refs.menu)
-    } 
+    }
   },
   mounted() {
     this.$root.$on('show', this.show);
@@ -126,5 +126,5 @@ export default {
   margin-top: -20px
   margin-left: -$width/2
   .search
-    @extend .item
+    @extend .rete-context-menu-item
 </style>


### PR DESCRIPTION
Referring to #63 , here is a PR with a more specific class name for the context menu items.