### PR TITLE
Fix item with subitems crash when clicked

### DIFF
--- a/src/presets/classic/factory.ts
+++ b/src/presets/classic/factory.ts
@@ -28,6 +28,7 @@ export function createItem<S extends BSchemes>(
   }
   return <Item>{
     ...item,
+    handler() {/* do nothing */},
     subitems: factory.map((data, i) => createItem(data, i, context))
   }
 }


### PR DESCRIPTION
Add dummy handler to item with subitems to prevent crashing. Fixes #81.